### PR TITLE
fix: filter schedules by title

### DIFF
--- a/FrontEnd/src/modules/schedule/handlers/schedule.handlers.ts
+++ b/FrontEnd/src/modules/schedule/handlers/schedule.handlers.ts
@@ -22,16 +22,18 @@ export const useHandleSchedule = () => {
         hour: 'numeric',
         minute: 'numeric',
       });
-
-      return {
-        day,
-        startTime,
-        endTime,
-        tags,
-        place,
-        title,
-        users: users.sort(() => 0.5 - Math.random()),
-      };
+      const scheduleCard : ScheduleCardProps = {
+        data:{
+          day,
+          startTime,
+          endTime,
+          tags,
+          place,
+          title,
+          users: users.sort(() => 0.5 - Math.random()),
+        }
+      }
+      return scheduleCard;
     },
     []
   );

--- a/FrontEnd/src/modules/schedule/pages/Schedule.tsx
+++ b/FrontEnd/src/modules/schedule/pages/Schedule.tsx
@@ -8,14 +8,17 @@ import { useHandleSchedule } from '../handlers/schedule.handlers';
 export const Schedule = () => {
   const { schedules, listSchedule, status } = useSchedule();
   const { handleSchedule } = useHandleSchedule();
-  const [search, setSearch] = useState<string>();
+  const [search, setSearch] = useState<string>('');
 
-  const loadCategories = useCallback(
-    (p = 1) => {
-      listSchedule({ page: p });
-    },
-    [listSchedule]
-  );
+  const loadCategories = useCallback(() => {
+    listSchedule({ page: 1 });
+  }, [listSchedule]);
+
+  const filteredSchedules = search
+    ? schedules.filter(schedule =>
+        schedule.title.toLowerCase().includes(search.toLowerCase())
+      )
+    : schedules;
 
   useEffect(() => {
     loadCategories();
@@ -26,10 +29,10 @@ export const Schedule = () => {
       <SearchBar
         placeholder="Pesquise por nome ou local da agenda"
         isSearching={status === 'searching'}
-        onChange={(value: string) => setSearch(value)}
+        onChange={(value: string) => setSearch(value.trim())}
       />
-      {schedules.map(schedule => (
-        <ScheduleCard data={handleSchedule(schedule)} />
+      {filteredSchedules.map(schedule => (
+        <ScheduleCard key={schedule.id} data={handleSchedule(schedule).data} />
       ))}
     </Flex>
   );


### PR DESCRIPTION
### 1 - Descrição do bug:

Não está sendo possível filtrar as agendas. 

**Exemplo:** Filtrar por nome "Festinha Dev Yazo" para aparecer somente essa agenda.

### 2 - Análise do bug:

Durante a code review notei que:

- O estado “**search**” estava sem “**value”** inicial;
- O estado “**search**” não estava sendo usado;
- A função “**loadCategories**” estava com codigo inutil;
- O “**ScheduleCard**” estava indicando erro na prop “**data**”.

### 3 - Solução do bug:

**PATH**: Support-Guy-Yazo-Challenge\FrontEnd\src\modules\schedule\pages\Schedule.tsx

11: eu adicionei o “**value**” inicial do “**useState**” para uma  string valizia “”.

12 a 15: na função “**useCallback**” estava sendo um parâmetro que não fazia diferença no seu funcionamento, logo eu removi e passei com “**1**” para o hook “**listSchedule”.**

17 a 21: eu criei uma const “**filteredSchedules**” para armazenar as “**schedules**” com base no estado “**search**”, se esse estado não estiver vazio, utilizo o método “**filter**” para percorrer o array “**schedules**”, assim filtrando as agendas com base no seu “**title**” se contenham as strings de “**search**”, caso contrário, ele usa todos os “**schedules**”.

31: eu defini que a função  “**onChange**”  recebe um valor “value” que é passado pro “**setSearch**” para atualizar o valor de search apenas se não estiver com espaços digitados na “**SearchBar**” .

34 e 35: eu substitui o array que era passado para o metodo “**map**” para o  “**filteredSchedules**” e adicionei a “**key**” é uma propriedade obrigatória em listas , que ajuda a identificar de forma única cada item da lista.

na propriedade “**data**” estava recebendo o “**handleSchedule**” que função, esse hook recebe um objeto do tipo “**ISchedule**” e retorna um objeto do tipo “**ScheduleCardProps**”, mas no entanto não estava retornando o objeto completo ocasionado um erro.

**PATH**: Support-Guy-Yazo-Challenge\FrontEnd\src\modules\schedule\handlers\schedule.handlers.ts 

25 a 36: criei uma const “**scheduleCard**” com o tipo “**ScheduleCardProps**” , estruturei com valores que eram passos como retorno anteriormente, e passei essa const como retorno da função.

**PATH**: Support-Guy-Yazo-Challenge\FrontEnd\src\modules\schedule\pages\Schedule.tsx

34 e 35: na prop “**data**” utilizei “**handleSchedule**”  passando o “**schedule**” que estava sendo percorrido e no final do hook  adicionei a prop “data” para pegar o data do “**schedule**” e passar corretamente o “data” para o componente “**ScheduleCard**”.

### 4 - Testes e validação:

Após as alterações eu Marco Antonio testei o input com "Festinha Dev Yazo” e me apresentou apenas o “**scheduleCard**” correto.